### PR TITLE
Makefile for bootstrapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+# Declare subcommands as "phony" targets, since they're not directories.
+.PHONY: roles clean build test help
+
+roles:
+	ansible-galaxy install -r requirements.yml --force -p roles/
+
+clean:
+	rm -rf roles/
+
+build:
+	make roles
+	molecule converge
+
+test:
+	make roles
+	molecule test --destroy never
+
+help:
+	@echo Makefile for configuring a local ELK dev environment.
+	@echo Subcommands:
+	@echo "\t roles: Fetch dependency Ansible roles for ELK config."
+	@echo "\t clean: Remove previously downloaded roles from roles/ directory."
+	@echo "\t build: Creates Vagrant VMs and provisions them via Ansible."
+	@echo "\t test: Creates Vagrant VMs, provisions, and verifies them."

--- a/README.md
+++ b/README.md
@@ -13,38 +13,47 @@ and a logclient, provision them, then run separate ServerSpec test suites
 against each host. In the near future there will be actual integration tests
 that confirm logs are flowing between the two hosts.
 
-## Running the tests
+## Requirements
 
-The project uses [Molecule] and [ServerSpec] for testing. You'll also need
-to download the role dependencies via ansible-galaxy. If you're testing
-feature branches, make sure to update the `version:` string in `requirements.yml`,
-to pull from the correct target. Then:
+* [Vagrant]
+* [Molecule]
+* [Serverspec]
 
+This should get you most of the way there:
 ```
-ansible-galaxy install -r requirements.yml --force
 pip install molecule
 gem install serverspec
-molecule test
 ```
 
-You can also run selective commands:
+## Running the tests
 
-```
-molecule idempotence
-molecule verify
-```
-See the [Molecule] docs for more info.
 There's a wrapper script that handles most of these actions so you can run a full
 integration test:
+```
+make test
+```
+
+Once the hosts are created, you can also run selective commands:
 
 ```
-./test.sh
+molecule converge
+molecule verify
+molecule login logserver
 ```
 
+See the [Molecule] docs for more info.
+
+### Testing caveats
+
+The test suite is mostly just chained unittests; there aren't any true integrations tests yet.
+Still, the integrated environment does allow full interaction between server and host VMs,
+and is quite useful when developing the dependent roles. True integration tests should be
+committed to this repo, rather than to the dependent roles.
 
 ## License
 MIT
 
+[Vagrant]: https://www.vagrantup.com/docs/
 [Molecule]: http://molecule.readthedocs.org/en/master/
 [ServerSpec]: http://serverspec.org/
 [freedomofpress.generate-ssl-cert]: https://github.com/freedomofpress/ansible-role-generate-ssl-cert

--- a/molecule.yml
+++ b/molecule.yml
@@ -23,7 +23,8 @@ vagrant:
     - name: logserver
       interfaces:
         - network_name: private_network
-          type: dhcp
+          type: static
+          ip: "192.168.10.2"
           auto_config: true
       raw_config_args:
         - "vm.network 'forwarded_port', guest: 443, host: 4443"
@@ -35,7 +36,8 @@ vagrant:
     - name: webserver
       interfaces:
         - network_name: private_network
-          type: dhcp
+          type: static
+          ip: "192.168.10.3"
           auto_config: true
       ansible_groups:
         - logclients

--- a/molecule.yml
+++ b/molecule.yml
@@ -13,11 +13,6 @@ vagrant:
   providers:
     - name: virtualbox
       type: virtualbox
-      options:
-        # Extra RAM mostly for logserver. Molecule doesn't support
-        # per-host memory overrides, although a custom Vagrantfile template
-        # would do the trick.
-        memory: 1024
 
   instances:
     - name: logserver
@@ -26,14 +21,19 @@ vagrant:
           type: static
           ip: "192.168.10.2"
           auto_config: true
-      raw_config_args:
-        - "vm.network 'forwarded_port', guest: 443, host: 4443"
-        - "vm.network 'forwarded_port', guest: 80, host: 8080"
       ansible_groups:
         - logserver
         - riemann
       raw_config_args:
+        - "vm.network 'forwarded_port', guest: 443, host: 4443"
+        - "vm.network 'forwarded_port', guest: 80, host: 8080"
         - "vm.synced_folder './', '/vagrant', disabled: true"
+        # Use block-style notation to increase RAM only for logserver.
+        - |-
+          vm.provider 'virtualbox' do |vb|
+            vb.memory = 2048
+            vb.cpus = 2
+          end
 
     - name: webserver
       interfaces:

--- a/molecule.yml
+++ b/molecule.yml
@@ -32,6 +32,8 @@ vagrant:
       ansible_groups:
         - logserver
         - riemann
+      raw_config_args:
+        - "vm.synced_folder './', '/vagrant', disabled: true"
 
     - name: webserver
       interfaces:
@@ -41,6 +43,8 @@ vagrant:
           auto_config: true
       ansible_groups:
         - logclients
+      raw_config_args:
+        - "vm.synced_folder './', '/vagrant', disabled: true"
 
 ansible:
   playbook: playbook.yml

--- a/molecule.yml
+++ b/molecule.yml
@@ -48,4 +48,5 @@ vagrant:
 
 ansible:
   playbook: playbook.yml
+  config_file: ansible.cfg
   sudo: no

--- a/playbook.yml
+++ b/playbook.yml
@@ -5,12 +5,34 @@
   tasks:
     - setup:
 
+# This is a hack to get around the bizarre variable precedence for dependency roles.
+# Since the ssl-generate-certificate role is a dependency of elk, play-level vars
+# are ignored in the context of the ssl dependency role. Storing the vars in the elk
+# role's vars directory resolves, but it's a messy solution.
+- name: Configure var overrides for testing.
+  hosts: logserver
+  gather_facts: no
+  vars:
+    logserver_integration_tests_var_overrides:
+      elk_configure_firewall: no
+      ssl_certificate_ip_address: "{{ hostvars.logserver.ansible_eth1.ipv4.address }}"
+  tasks:
+    - name: Creates temporary vars dir in local elk role.
+      local_action:
+        module: file
+        state: directory
+        path: ./roles/freedomofpress.elk/vars
+
+    - name: Write temporary vars file to local elk role.
+      local_action:
+        module: copy
+        content: "{{ logserver_integration_tests_var_overrides|to_nice_yaml }}"
+        dest: ./roles/freedomofpress.elk/vars/main.yml
+
 - name: Stand up logserver.
   hosts: logserver
   roles:
     - role: freedomofpress.elk
-      elk_network_interface: eth1
-      ssl_certificate_ip_address: "{{ ansible_eth1.ipv4.address }}"
       become: yes
       tags: elk
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,18 @@
+require 'serverspec'
+require 'net/ssh'
+
+host = ENV['TARGET_HOST']
+ssh_config_files = ['./.vagrant/ssh-config'] + Net::SSH::Config.default_files
+options = Net::SSH::Config.for(host, ssh_config_files)
+options[:user] ||= 'vagrant'
+options[:keys].push("#{Dir.home}/.vagrant.d/insecure_private_key")
+
+set :backend, :ssh
+set :host, host
+set :ssh_options, options
+
+RSpec.configure do |config|
+  config.color = true
+  config.tty = true
+  config.formatter = :documentation
+end


### PR DESCRIPTION
Provides a `Makefile` as a simpler alternative to custom bash scripts for wrapping the common test commands. Handles collecting the dependent roles from Ansible Galaxy, as well as running the primary molecule test subcommands.

Also implements a rather unintuitive and implicit method for variable overrides, due to precedence problems in Ansible v2. Added a custom play to the testing playbook that writes test vars to the elk role's vars folder, so they override the generate-ssl-cert role vars. Not happy with that solution, but it works, and precedence may change in subsequent versions of Ansible, so it's worth waiting to see what shakes out.
